### PR TITLE
public narratives now "just" public -- includes owned and shared-with

### DIFF
--- a/src/plugin/modules/widgets/PublicNarrativesWidget.js
+++ b/src/plugin/modules/widgets/PublicNarrativesWidget.js
@@ -127,43 +127,43 @@ define([
                     }
                     var searchRe = new RegExp(options.search, 'i'),
                         nar = this.getState('narratives').filter(function (x) {
-                        if (
-                            x.workspace.metadata.narrative_nice_name.match(searchRe)
+                            if (
+                                x.workspace.metadata.narrative_nice_name.match(searchRe)
 
-                            ||
-                            
-                             x.workspace.owner.match(searchRe)
+                                ||
 
-                            ||
-                            
-                            (x.object.metadata.cellInfo &&
-                                (function (apps) {
-                                    for (var i in apps) {
-                                        var app = apps[i];
-                                        if (app.match(searchRe) || this.getAppName(app).match(searchRe)) {
-                                            return true;
+                                 x.workspace.owner.match(searchRe)
+
+                                ||
+
+                                (x.object.metadata.cellInfo &&
+                                    (function (apps) {
+                                        for (var i in apps) {
+                                            var app = apps[i];
+                                            if (app.match(searchRe) || this.getAppName(app).match(searchRe)) {
+                                                return true;
+                                            }
                                         }
-                                    }
-                                }.bind(this))(Object.keys(x.object.metadata.cellInfo.app)))
+                                    }.bind(this))(Object.keys(x.object.metadata.cellInfo.app)))
 
-                            ||
-                            
-                            (x.object.metadata.cellInfo &&
-                                (function (methods) {
-                                    for (var i in methods) {
-                                        var method = methods[i];
-                                        if (method.match(searchRe) || this.getMethodName(method).match(searchRe)) {
-                                            return true;
+                                ||
+
+                                (x.object.metadata.cellInfo &&
+                                    (function (methods) {
+                                        for (var i in methods) {
+                                            var method = methods[i];
+                                            if (method.match(searchRe) || this.getMethodName(method).match(searchRe)) {
+                                                return true;
+                                            }
                                         }
-                                    }
-                                }.bind(this))(Object.keys(x.object.metadata.cellInfo.method)))
+                                    }.bind(this))(Object.keys(x.object.metadata.cellInfo.method)))
 
-                            ) {
-                            return true;
-                        } else {
-                            return false;
-                        }
-                    }.bind(this));
+                                ) {
+                                return true;
+                            } else {
+                                return false;
+                            }
+                        }.bind(this));
                     this.setState('narrativesFiltered', nar);
                 }
             },
@@ -196,16 +196,6 @@ define([
                         excludeGlobal: 0
                     })
                         .then(function (narratives) {
-                            var username = this.runtime.getService('session').getUsername();
-                            narratives = narratives.filter(function (x) {
-                                if (x.workspace.owner === username ||
-                                    x.workspace.user_permission !== 'n') {
-                                    return false;
-                                } else {
-                                    return true;
-                                }
-                            }.bind(this));
-
                             this.setState('narratives', narratives);
                             this.setState('narrativesFiltered', narratives);
                         }.bind(this));

--- a/src/plugin/modules/widgets/SharedNarrativesWidget.js
+++ b/src/plugin/modules/widgets/SharedNarrativesWidget.js
@@ -135,10 +135,10 @@ define([
             onStateChange: {
                 value: function () {
                     var count = this.doState('narratives', function (x) {
-                        return x.length
+                        return x.length;
                     }, null);
                     var filtered = this.doState('narrativesFiltered', function (x) {
-                        return x.length
+                        return x.length;
                     }, null);
 
                     this.viewState.setItem('sharedNarratives', {
@@ -153,7 +153,7 @@ define([
                         token: this.runtime.service('session').getAuthToken()
                     });
                     return Promise.all([
-                        methodStore.list_apps({}),
+                        methodStore.list_apps({})
                     ])
                         .spread(function (apps) {
                             var appMap = {};

--- a/src/plugin/resources/NarrativesWidget/templates/slider.html
+++ b/src/plugin/resources/NarrativesWidget/templates/slider.html
@@ -165,7 +165,7 @@
                 </span>
                 {% endif %} 
                 {% if narrative.workspace.globalread == 'r' or narrative.workspace.globalread == 'w' %} 
-                <span class="fa fa-globe"  data-toggle="tooltip" data-placement="auto" title="This narrative is Publicly available (read-only)" data-container="body"></span>
+                <span class="fa fa-globe"  data-toggle="tooltip" data-placement="auto" title="This narrative is Publicly available" data-container="body"></span>
                 {% endif %}
             </div><div style="display:inline-block; width: 33%;text-align: center;">
                 {% set runningJobs = narrative.object.metadata.jobInfo.running %}

--- a/src/plugin/resources/PublicNarrativesWidget/templates/slider.html
+++ b/src/plugin/resources/PublicNarrativesWidget/templates/slider.html
@@ -144,7 +144,13 @@
         <div class="-footer">
             <div style="display:inline-block; width: 33%;text-align: center;">
                 {% if narrative.workspace.user_permission == 'r' %}
-                <span class="fa fa-minus dimmed"  style="opacity: 0.4;" data-toggle="tooltip" data-placement="auto" title="Sharing information not available for this Narrative" data-container="body"></span> {% else %} {% if narrative.permissions|length > 0 %} {{ narrative.permissions | length }} {% else %} 0 {% endif %} <span class="fa fa-share-alt"  data-toggle="tooltip" data-placement="auto" title="The number of other users with whom this Narrative has been shared" data-container="body"></span> {% endif %} {% if narrative.workspace.globalread == 'r' or narrative.workspace.globalread == 'w' %} P{% endif %}
+                <span class="fa fa-minus dimmed"  style="opacity: 0.4;" data-toggle="tooltip" data-placement="auto" title="Sharing information not available for this Narrative" data-container="body"></span> {% else %} 
+                {% if narrative.permissions|length > 0 %} {{ narrative.permissions | length }} {% else %} 0 {% endif %} 
+                <span class="fa fa-share-alt"  data-toggle="tooltip" data-placement="auto" title="The number of other users with whom this Narrative has been shared" data-container="body"></span> {% endif %} 
+                
+                 {% if narrative.workspace.globalread == 'r' or narrative.workspace.globalread == 'w' %} 
+                <span class="fa fa-globe"  data-toggle="tooltip" data-placement="auto" title="This narrative is Publicly available" data-container="body"></span>
+                {% endif %}
             </div><div style="display:inline-block; width: 33%;text-align: center;">
 
                 {% set runningJobs = narrative.object.metadata.jobInfo.running %}

--- a/src/plugin/resources/SharedNarrativesWidget/templates/slider.html
+++ b/src/plugin/resources/SharedNarrativesWidget/templates/slider.html
@@ -155,7 +155,7 @@
                 </span>
                 {% endif %} 
                 {% if narrative.workspace.globalread == 'r' or narrative.workspace.globalread == 'w' %} 
-                <span class="fa fa-globe"  data-toggle="tooltip" data-placement="auto" title="This narrative is Publicly available (read-only)" data-container="body"></span>
+                <span class="fa fa-globe"  data-toggle="tooltip" data-placement="auto" title="This narrative is Publicly available" data-container="body"></span>
                 {% endif %}
             </div><div style="display:inline-block; width: 33%;text-align: center;">
 


### PR DESCRIPTION
The public narratives originally showed only public narratives which where NOT already shown as owned by or shared with the current user.
This change removes those filters, so that the panel shows all public narratives the current user has access to.
Also, remove "(read-only)" from the public icon mouseover (it is confusing), and some minor code cleanup.
