### PR TITLE
Remove kb deps from bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,10 +20,7 @@
         "bluebird": "^3.0.0",
         "bootstrap": "^3.3.0",
         "nunjucks": "^1.3.0",
-        "jquery": "^2.1.0",
-        "kbase-common-js": "^2.0.0",
-        "kbase-ui-widget": "^1.0.0",
-        "kbase-service-clients-js": "^3.1.1"
+        "jquery": "^2.1.0"
     },
     "devDependencies": {
     },


### PR DESCRIPTION
Since kbase-ui supports multiple kb libs now, under different roots (e.g. kb_common, kb/common), for the time being we cannot use the correct dependencies expression, because bower can't deal with multiple versionsn of deps directly (in terms of the dep tree) and certainly can't map those back to the AMD module root name.